### PR TITLE
Fix invalid YouTube link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,4 +20,4 @@ Building Dev Tooling with the best technology to our open-source community and t
 ## Connect With Us 🫂
 - Join our [Slack community](https://slack.loft.sh/) to learn more.
 - Follow us on [Twitter](https://twitter.com/loft_sh) for the latest updates.
-- Learn more on [YouTube](https://www.youtube.com/@loft_sh).
+- Learn more on [YouTube](https://www.youtube.com/@vcluster).


### PR DESCRIPTION
The existing link was pointing to https://www.youtube.com/@loft_sh which was throwing a 404. Updated that with @vcluster